### PR TITLE
Create Example Publisher and Consumer

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,7 +7,6 @@ gem "rails", "5.2.3"
 
 gem "bootsnap", ">= 1.1.0", require: false
 gem "jbuilder", "~> 2.5"
-gem "nokogiri"
 gem "pg"
 gem "puma", "~> 3.11"
 gem "sass-rails", "~> 5.0"

--- a/Gemfile
+++ b/Gemfile
@@ -7,6 +7,7 @@ gem "rails", "5.2.3"
 
 gem "bootsnap", ">= 1.1.0", require: false
 gem "jbuilder", "~> 2.5"
+gem "nokogiri"
 gem "pg"
 gem "puma", "~> 3.11"
 gem "sass-rails", "~> 5.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -202,6 +202,7 @@ DEPENDENCIES
   chromedriver-helper
   jbuilder (~> 2.5)
   listen (>= 3.0.5, < 3.2)
+  nokogiri
   pg
   puma (~> 3.11)
   rails (= 5.2.3)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -202,7 +202,6 @@ DEPENDENCIES
   chromedriver-helper
   jbuilder (~> 2.5)
   listen (>= 3.0.5, < 3.2)
-  nokogiri
   pg
   puma (~> 3.11)
   rails (= 5.2.3)

--- a/app/messengers/contrived_messenger.rb
+++ b/app/messengers/contrived_messenger.rb
@@ -8,11 +8,11 @@ class ContrivedMessenger
   def run
     connection.start
     channel = connection.create_channel
-    exchange = channel.direct("direct_messages")
+    queue = channel.queue(routing_key, durable: true)
 
-    exchange.publish(message, routing_key: routing_key)
+    channel.default_exchange.publish(message, routing_key: queue.name)
 
-    puts("Broadcasting that publisher did a thing: #{message}:#{routing_key}")
+    puts("    💌 Publisher has published: #{message}:#{routing_key}")
 
     connection.close
   end

--- a/app/messengers/contrived_messenger.rb
+++ b/app/messengers/contrived_messenger.rb
@@ -1,0 +1,27 @@
+class ContrivedMessenger
+  def initialize(
+    message: "contrived message!",
+    route: "contrived_route_one",
+    connection_client: Bunny.new
+  )
+    @connection = connection_client
+    @message = message
+    @routing_key = route
+  end
+
+  def run
+    connection.start
+    channel = connection.create_channel
+    exchange = channel.direct("direct_messages")
+
+    exchange.publish(message, routing_key)
+
+    puts("Broadcasting that publisher did a thing: #{message}:#{routing_key}")
+
+    connection.close
+  end
+
+  private
+
+  attr_accessor :connection, :message, :routing_key
+end

--- a/app/messengers/contrived_messenger.rb
+++ b/app/messengers/contrived_messenger.rb
@@ -14,7 +14,7 @@ class ContrivedMessenger
     channel = connection.create_channel
     exchange = channel.direct("direct_messages")
 
-    exchange.publish(message, routing_key)
+    exchange.publish(message, routing_key: routing_key)
 
     puts("Broadcasting that publisher did a thing: #{message}:#{routing_key}")
 

--- a/app/messengers/contrived_messenger.rb
+++ b/app/messengers/contrived_messenger.rb
@@ -1,6 +1,6 @@
 class ContrivedMessenger
   def initialize(
-    message: "contrived message!",
+    message: "contrived message for worker",
     route: "contrived_route_one",
     connection_client: Bunny.new
   )

--- a/app/messengers/contrived_messenger.rb
+++ b/app/messengers/contrived_messenger.rb
@@ -1,9 +1,5 @@
 class ContrivedMessenger
-  def initialize(
-    message: "contrived message for worker",
-    route: "contrived_route_one",
-    connection_client: Bunny.new
-  )
+  def initialize(message:, route:, connection_client: Bunny.new)
     @connection = connection_client
     @message = message
     @routing_key = route

--- a/app/workers/contrived_worker.rb
+++ b/app/workers/contrived_worker.rb
@@ -1,5 +1,3 @@
-require "nokogiri"
-require "open-uri"
 require "sneakers"
 require "sneakers/metrics/logging_metrics"
 
@@ -14,13 +12,11 @@ class ContrivedWorker
   )
 
   def work(msg)
-    doc = Nokogiri::HTML(open(msg))
+    contrived_work = msg.tr("work", "👩‍🏭")
 
-    page_title = doc.css("title").text
+    puts("Broadcasting that this worker did a thing: #{contrived_work}")
 
-    puts("Broadcasting that this worker did a thing: #{page_title}")
-
-    worker_trace "Found: #{page_title}"
+    worker_trace "Found: #{contrived_work}"
 
     ack!
   end

--- a/app/workers/contrived_worker.rb
+++ b/app/workers/contrived_worker.rb
@@ -7,7 +7,7 @@ class ContrivedWorker
   include Sneakers::Worker
 
   from_queue(
-    :direct_messages,
+    :contrived_route_one,
     threads: 50,
     prefetch: 50,
     timeout_job_after: 1

--- a/app/workers/contrived_worker.rb
+++ b/app/workers/contrived_worker.rb
@@ -7,7 +7,7 @@ class ContrivedWorker
   include Sneakers::Worker
 
   from_queue(
-    :contrived_worker_stuff,
+    :direct_messages,
     threads: 50,
     prefetch: 50,
     timeout_job_after: 1
@@ -18,7 +18,7 @@ class ContrivedWorker
 
     page_title = doc.css("title").text
 
-    puts "Broadcasting that this worker did a thing: #{page_title}"
+    puts("Broadcasting that this worker did a thing: #{page_title}")
 
     worker_trace "Found: #{page_title}"
 

--- a/app/workers/contrived_worker.rb
+++ b/app/workers/contrived_worker.rb
@@ -1,0 +1,25 @@
+require "nokogiri"
+require "open-uri"
+require "sneakers"
+require "sneakers/metrics/logging_metrics"
+
+class ContrivedWorker
+  include Sneakers::Worker
+
+  from_queue(
+    :contrived_worker_stuff,
+    threads: 50,
+    prefetch: 50,
+    timeout_job_after: 1
+  )
+
+  def work(msg)
+    doc = Nokogiri::HTML(open(msg))
+
+    page_title = doc.css("title").text
+
+    worker_trace "Found: #{page_title}"
+
+    ack!
+  end
+end

--- a/app/workers/contrived_worker.rb
+++ b/app/workers/contrived_worker.rb
@@ -18,6 +18,8 @@ class ContrivedWorker
 
     page_title = doc.css("title").text
 
+    puts "Broadcasting that this worker did a thing: #{page_title}"
+
     worker_trace "Found: #{page_title}"
 
     ack!

--- a/lib/tasks/publish_message.rake
+++ b/lib/tasks/publish_message.rake
@@ -1,0 +1,12 @@
+
+namespace :publish do
+  desc "Publish a Message to an Exchange"
+  task message: :environment do 
+    puts "📯 Preparing to send a message"
+
+    cm = ContrivedMessenger.new
+    cm.run
+
+    puts "📭 Message sent \n\n"
+  end
+end

--- a/lib/tasks/publish_message.rake
+++ b/lib/tasks/publish_message.rake
@@ -1,10 +1,18 @@
 
 namespace :publish do
   desc "Publish a Message to an Exchange"
-  task message: :environment do 
-    puts "📯 Preparing to send a message"
+  task :message, [:msg, :route] => [:environment] do |_task, args|
+    message = args[:msg] || "contrived message for worker"
+    route = args[:route] || "contrived_route_one"
+    bunny = Bunny.new
 
-    cm = ContrivedMessenger.new
+    puts "📯 Preparing to send a message: #{message}"
+
+    cm = ContrivedMessenger.new(
+      message: message,
+      route: route,
+      connection_client: bunny
+    )
     cm.run
 
     puts "📭 Message sent \n\n"

--- a/lib/tasks/receive_message.rake
+++ b/lib/tasks/receive_message.rake
@@ -1,0 +1,28 @@
+#!/usr/bin/env ruby
+require "bunny"
+
+namespace :consume do
+  desc "Consume a Message via Bunny - to test alongside Sneakers"
+  task message: :environment do
+    connection = Bunny.new
+    connection.start
+
+    channel = connection.create_channel
+    queue = channel.queue("contrived_route_one", durable: true)
+
+    begin
+      puts " [👂] Waiting for messages. To exit press CTRL+C"
+      queue.subscribe(block: true) do |delivery_info, _properties, message|
+        puts " [📬] Received #{message}"
+        contrived_work = message.tr("work", "👩‍🏭")
+        puts " [✅] Finished processing message: #{contrived_work}"
+        channel.ack(delivery_info.delivery_tag)
+      end
+    rescue Interrupt => _
+      connection.close
+      puts " [👋] You are no longer listening to me talk!"
+
+      exit(0)
+    end
+  end
+end


### PR DESCRIPTION
To get the app talking to itself and using `Sneakers`, a basic example publisher and worker have been created. These serve as a starting point for using `Sneakers` over the web, and can be expanded upon for more experimentation. 